### PR TITLE
Make package installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "repository": "git@github.com:kipr/ivygate.git",
   "author": "Braden McDorman",
-  "license": "GPL3",
+  "license": "GPL-3.0-only",
   "files": [
     "./dist/"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivygate",
-  "version": "1.0.2",
+  "version": "0.1.0",
   "description": "Botball IDE",
   "main": "./dist/index.js",
   "repository": "git@github.com:kipr/ivygate.git",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "git@github.com:kipr/ivygate.git",
   "author": "Braden McDorman",
   "license": "GPL3",
+  "scripts": {
+    "build": "tsc",
+    "prepare": "yarn run build"
+  },
   "dependencies": {
     "monaco": "^1.201704190613.0",
     "monaco-editor": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:kipr/ivygate.git",
   "author": "Braden McDorman",
   "license": "GPL3",
+  "files": [
+    "./dist/"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "yarn run build"


### PR DESCRIPTION
Related to kipr/Simulator#172

- Adds `prepare` script to build ivygate whenever it is installed as a package
- In the `files` section of `package.json`, explicitly includes the `dist` folder so it doesn't get ignored due to `.gitignore`
- Reset the version to `0.1.0` (a good starting version for a package in development that will have lots of breaking changes)