### PR TITLE
Add indentation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivygate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Botball IDE",
   "main": "./dist/index.js",
   "repository": "git@github.com:kipr/ivygate.git",
@@ -25,6 +25,8 @@
   },
   "types": "./dist/index.d.ts",
   "devDependencies": {
+    "@types/js-beautify": "^1.13.3",
+    "@types/prettier": "^2.4.3",
     "@types/react-dom": "^17.0.2",
     "@types/styletron-react": "^5.0.2",
     "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   },
   "types": "./dist/index.d.ts",
   "devDependencies": {
-    "@types/js-beautify": "^1.13.3",
-    "@types/prettier": "^2.4.3",
     "@types/react-dom": "^17.0.2",
     "@types/styletron-react": "^5.0.2",
     "typescript": "^4.2.3"

--- a/src/Ivygate.tsx
+++ b/src/Ivygate.tsx
@@ -64,7 +64,7 @@ export class Ivygate extends React.PureComponent<Props, State> {
     super(props);
   }
 
-  private editor_: monaco.editor.IEditor;
+  editor_: monaco.editor.IEditor;
 
   private ref_: HTMLDivElement;
   private bindRef_ = (ref: HTMLDivElement) => {
@@ -87,6 +87,11 @@ export class Ivygate extends React.PureComponent<Props, State> {
 
     const model = this.editor_.getModel() as monaco.editor.ITextModel;
     model.onDidChangeContent(this.onContentChange_);
+  }
+
+  formatCode() {
+    this.editor_.trigger('anyString', 'editor.action.formatDocument', null);
+    //  "editor.action.reindentlines",
   }
 
   private handle_?: number;
@@ -165,7 +170,10 @@ export class Ivygate extends React.PureComponent<Props, State> {
     const { props } = this;
     const { style, className } = props;
     return (
-      <div style={{ width: '100%', height: '100%', ...style }} className={className} ref={this.bindRef_} />
+      <>
+        <button onClick={ () => this.formatCode }>Format</button>
+        <div style={{ width: '100%', height: '100%', ...style }} className={className} ref={this.bindRef_} />
+      </>
     );
   }
 }

--- a/src/c-indent.ts
+++ b/src/c-indent.ts
@@ -1,0 +1,76 @@
+
+/**
+ * basic indentation based on bracket, parens, and brace level
+ * should work okay for the immediate future
+ * Complexity: O(n) time (n chars in line), O(n+m) space (m parens in line)
+ * 
+ * @param line 
+ * @returns [
+ *  number: The change in indent level of this line (<=0, if a brace is closed)
+ *  number: The indent level of the following line, based on this line (>= 0, if a brace is opened)
+ * ]
+ */
+function getIndentationChange(line: string): [number, number] {
+  let indentLevel = 0;
+  const parenOpenList = ['(','[','{']
+  const parenCloseList = [')',']','}']
+  let parenStack = []
+  for (let i = 0; i < line.length; i++) {
+    if (parenOpenList.indexOf(line.charAt(i)) !== -1) {
+      parenStack.push(line.charAt(i));
+    } else if (
+      (line.charAt(i) === ')' && parenStack[parenStack.length - 1] === '(') ||
+      (line.charAt(i) === ']' && parenStack[parenStack.length - 1] === '[') ||
+      (line.charAt(i) === '}' && parenStack[parenStack.length - 1] === '{')
+    ) {
+      parenStack.pop();
+    } else if (parenCloseList.indexOf(line.charAt(i)) !== -1) {
+      // closing paren without opening paren, decrease indent
+      indentLevel -= 1;
+    }
+  }
+  return [indentLevel, parenStack.length];
+}
+
+/**
+ * Indent the provided c code
+ * 
+ * @param code The code string
+ * @param options Any options for the indentation
+ * @returns The indented code string
+ */
+function format(code: string, tabSize: number, insertSpaces: boolean): string {
+  let indentLevel = 0;
+  
+  let indentStr: string;
+  if (insertSpaces) {
+    indentStr = ' '.repeat(tabSize);
+  } else {
+    indentStr = '\t';
+  }
+
+  // first, trim off any extra lines or space at the top
+  let linesOfCode = code.trim().split('\n');
+  let indentedCode = '';
+  linesOfCode.forEach((line) => {
+    let newline = line.trim();
+
+    let [lineIndentChange, postLineIndentChange] = getIndentationChange(newline);
+    indentLevel = Math.max(0, indentLevel + lineIndentChange);
+
+    // do the indentation
+    if (indentLevel > 0) {
+      newline = indentStr.repeat(indentLevel) + newline + '\n';
+    } else {
+      newline = newline + '\n';
+    }
+
+    indentLevel = Math.max(0, indentLevel + postLineIndentChange);
+    
+    indentedCode += newline;
+  });
+
+  return indentedCode;
+}
+
+export default format;

--- a/src/c-indent.ts
+++ b/src/c-indent.ts
@@ -49,8 +49,7 @@ function format(code: string, tabSize: number, insertSpaces: boolean): string {
     indentStr = '\t';
   }
 
-  // first, trim off any extra lines or space at the top
-  let linesOfCode = code.trim().split('\n');
+  let linesOfCode = code.split('\n');
   let indentedCode = '';
   linesOfCode.forEach((line) => {
     let newline = line.trim();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@types/js-beautify@^1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/js-beautify/-/js-beautify-1.13.3.tgz#53839bb5b766d0fb45e87386100bb3bcbb7dca9d"
+  integrity sha512-ucIPw5gmNyvRKi6mpeojlqp+T+6ZBJeU+kqMDnIEDlijEU4QhLTon90sZ3cz9HZr+QTwXILjNsMZImzA7+zuJA==
+
+"@types/prettier@^2.4.3":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
+  integrity sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/js-beautify@^1.13.3":
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/@types/js-beautify/-/js-beautify-1.13.3.tgz#53839bb5b766d0fb45e87386100bb3bcbb7dca9d"
-  integrity sha512-ucIPw5gmNyvRKi6mpeojlqp+T+6ZBJeU+kqMDnIEDlijEU4QhLTon90sZ3cz9HZr+QTwXILjNsMZImzA7+zuJA==
-
-"@types/prettier@^2.4.3":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
-  integrity sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
-
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"


### PR DESCRIPTION
Added support for indentation (or any custom formatter) for the Monaco editor.

This is in the form of an indentation function (c-indent), which uses braces / parenthesis to determine indentation level, and a callback in Ivygate to change the formatting function to any desired function. 

Additionally, if the user sets the language to C, the c-indent function is automatically set to be the formatting function. If other languages are used, Monaco may already have a formatting function defined (such as in JavaScript).

